### PR TITLE
프로젝트 기반 환경 설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /.gradle/
 /.idea/
 /build/
+/gradle/
+WORK.md

--- a/README.md
+++ b/README.md
@@ -1,2 +1,55 @@
-# lemon-ticket
-공연 티켓을 예매할 수 있는 멜론티켓을 모티브로 만든 공연 티켓 예매 API 서버 프로젝트
+# 🍋 Lemon Ticket
+
+멜론티켓(Melon Ticket)을 모티브로 한 **공연 티켓 예매 API 서버** 프로젝트입니다.
+
+## 프로젝트 소개
+
+공연/콘서트 티켓을 검색하고 예매할 수 있는 RESTful API 서버입니다.
+동시 접속이 몰리는 티켓팅 환경에서의 동시성 제어와 안정적인 예매 처리를 목표로 합니다.
+
+## 기술 스택
+
+| 구분 | 기술 |
+|------|------|
+| Language | Java 17 |
+| Framework | Spring Boot 3.3 |
+| ORM | Spring Data JPA (Hibernate) |
+| Database | MySQL |
+| Build | Gradle |
+| API Docs | Swagger (springdoc-openapi) |
+| Test | JUnit 5, H2 (테스트용) |
+
+## 시작하기
+
+### 사전 요구사항
+
+- Java 17+
+- MySQL
+- 환경변수 설정: `DATABASE_USERNAME`, `DATABASE_PASSWORD`
+
+### 빌드 및 실행
+
+```bash
+# 빌드
+./gradlew build
+
+# 실행
+./gradlew bootRun
+
+# 테스트
+./gradlew test
+```
+
+실행 후 API 문서는 `/swagger-ui/index.html`에서 확인할 수 있습니다.
+
+## 프로젝트 구조
+
+```
+src/main/java/com/flab/lemonticket/
+├── LemonTicketApplication.java    # 애플리케이션 진입점
+├── controller/                    # REST API 컨트롤러 (예정)
+├── service/                       # 비즈니스 로직 (예정)
+├── repository/                    # 데이터 접근 계층 (예정)
+├── domain/                        # 엔티티/도메인 모델 (예정)
+└── dto/                           # 요청/응답 DTO (예정)
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.8'
+
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: lemon-ticket-mysql
+    ports:
+      - "3307:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: root1234
+      MYSQL_DATABASE: lemon_ticket
+      MYSQL_USER: lemon
+      MYSQL_PASSWORD: lemon1234
+    volumes:
+      - lemon-mysql-data:/var/lib/mysql
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --default-authentication-plugin=mysql_native_password
+
+volumes:
+  lemon-mysql-data:

--- a/src/main/java/com/flab/lemonticket/common/exception/BusinessException.java
+++ b/src/main/java/com/flab/lemonticket/common/exception/BusinessException.java
@@ -1,0 +1,19 @@
+package com.flab.lemonticket.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/flab/lemonticket/common/exception/DuplicateException.java
+++ b/src/main/java/com/flab/lemonticket/common/exception/DuplicateException.java
@@ -1,0 +1,12 @@
+package com.flab.lemonticket.common.exception;
+
+public class DuplicateException extends BusinessException {
+
+    public DuplicateException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public DuplicateException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/com/flab/lemonticket/common/exception/ErrorCode.java
+++ b/src/main/java/com/flab/lemonticket/common/exception/ErrorCode.java
@@ -1,0 +1,44 @@
+package com.flab.lemonticket.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // Common
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "잘못된 입력값입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C002", "서버 내부 오류가 발생했습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C003", "허용되지 않은 HTTP 메서드입니다."),
+
+    // Auth
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "인증이 필요합니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "A002", "접근 권한이 없습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A004", "만료된 토큰입니다."),
+
+    // Member
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "회원을 찾을 수 없습니다."),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "M002", "이미 사용 중인 이메일입니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "M003", "비밀번호가 일치하지 않습니다."),
+
+    // Event
+    EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "E001", "공연을 찾을 수 없습니다."),
+    EVENT_ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "E002", "이미 취소된 공연입니다."),
+
+    // Seat
+    SEAT_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "좌석을 찾을 수 없습니다."),
+    SEAT_ALREADY_BOOKED(HttpStatus.CONFLICT, "S002", "이미 예매된 좌석입니다."),
+    SEAT_ALREADY_LOCKED(HttpStatus.CONFLICT, "S003", "다른 사용자가 선점 중인 좌석입니다."),
+
+    // Booking
+    BOOKING_NOT_FOUND(HttpStatus.NOT_FOUND, "B001", "예매 정보를 찾을 수 없습니다."),
+    BOOKING_ALREADY_CANCELLED(HttpStatus.BAD_REQUEST, "B002", "이미 취소된 예매입니다."),
+    BOOKING_EXPIRED(HttpStatus.BAD_REQUEST, "B003", "만료된 예매입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/flab/lemonticket/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/flab/lemonticket/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,67 @@
+package com.flab.lemonticket.common.exception;
+
+import com.flab.lemonticket.common.response.ApiResponse;
+import com.flab.lemonticket.common.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+        log.warn("Validation failed: {}", e.getMessage());
+
+        List<ErrorResponse.FieldError> fieldErrors = e.getBindingResult().getFieldErrors().stream()
+                .map(error -> new ErrorResponse.FieldError(
+                        error.getField(),
+                        error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+                        error.getDefaultMessage()
+                ))
+                .collect(Collectors.toList());
+
+        ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ApiResponse.error(errorCode.getCode(), errorCode.getMessage(), fieldErrors));
+    }
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
+        log.warn("Business exception: {}", e.getMessage());
+
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ApiResponse.error(errorCode.getCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleHttpRequestMethodNotSupported(HttpRequestMethodNotSupportedException e) {
+        log.warn("Method not allowed: {}", e.getMessage());
+
+        ErrorCode errorCode = ErrorCode.METHOD_NOT_ALLOWED;
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ApiResponse.error(errorCode.getCode(), errorCode.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("Unexpected error occurred", e);
+
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error(errorCode.getCode(), errorCode.getMessage()));
+    }
+}

--- a/src/main/java/com/flab/lemonticket/common/exception/NotFoundException.java
+++ b/src/main/java/com/flab/lemonticket/common/exception/NotFoundException.java
@@ -1,0 +1,12 @@
+package com.flab.lemonticket.common.exception;
+
+public class NotFoundException extends BusinessException {
+
+    public NotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public NotFoundException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/com/flab/lemonticket/common/exception/UnauthorizedException.java
+++ b/src/main/java/com/flab/lemonticket/common/exception/UnauthorizedException.java
@@ -1,0 +1,12 @@
+package com.flab.lemonticket.common.exception;
+
+public class UnauthorizedException extends BusinessException {
+
+    public UnauthorizedException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public UnauthorizedException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/com/flab/lemonticket/common/response/ApiResponse.java
+++ b/src/main/java/com/flab/lemonticket/common/response/ApiResponse.java
@@ -1,0 +1,51 @@
+package com.flab.lemonticket.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+
+    private boolean success;
+    private T data;
+    private ErrorResponse error;
+
+    @Builder
+    private ApiResponse(boolean success, T data, ErrorResponse error) {
+        this.success = success;
+        this.data = data;
+        this.error = error;
+    }
+
+    public static <T> ApiResponse<T> ok(T data) {
+        return ApiResponse.<T>builder()
+                .success(true)
+                .data(data)
+                .build();
+    }
+
+    public static ApiResponse<Void> ok() {
+        return ApiResponse.<Void>builder()
+                .success(true)
+                .build();
+    }
+
+    public static ApiResponse<Void> error(String code, String message) {
+        return ApiResponse.<Void>builder()
+                .success(false)
+                .error(new ErrorResponse(code, message))
+                .build();
+    }
+
+    public static ApiResponse<Void> error(String code, String message, java.util.List<ErrorResponse.FieldError> fieldErrors) {
+        return ApiResponse.<Void>builder()
+                .success(false)
+                .error(new ErrorResponse(code, message, fieldErrors))
+                .build();
+    }
+}

--- a/src/main/java/com/flab/lemonticket/common/response/ErrorResponse.java
+++ b/src/main/java/com/flab/lemonticket/common/response/ErrorResponse.java
@@ -1,0 +1,36 @@
+package com.flab.lemonticket.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ErrorResponse {
+
+    private final String code;
+    private final String message;
+    private final List<FieldError> fieldErrors;
+
+    public ErrorResponse(String code, String message) {
+        this.code = code;
+        this.message = message;
+        this.fieldErrors = null;
+    }
+
+    public ErrorResponse(String code, String message, List<FieldError> fieldErrors) {
+        this.code = code;
+        this.message = message;
+        this.fieldErrors = fieldErrors;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class FieldError {
+        private final String field;
+        private final String value;
+        private final String reason;
+    }
+}

--- a/src/main/java/com/flab/lemonticket/config/SecurityConfig.java
+++ b/src/main/java/com/flab/lemonticket/config/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
                 .authorizeRequests(authorizeRequests ->
                         authorizeRequests
                                 .requestMatchers("/api/users/login", "/api/users/register", "/api/users/test_no_auth").permitAll()
+                                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**").permitAll()
                                 .requestMatchers("/api/users/test_normal").hasRole("USER")
                                 .requestMatchers("/api/users/test_event_admin").hasRole("ORGANIZER")
                                 .requestMatchers("/api/admin/**").hasRole("ADMIN")

--- a/src/main/java/com/flab/lemonticket/config/SwaggerConfig.java
+++ b/src/main/java/com/flab/lemonticket/config/SwaggerConfig.java
@@ -1,0 +1,36 @@
+package com.flab.lemonticket.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        String jwtSchemeName = "Bearer Token";
+
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList(jwtSchemeName);
+
+        SecurityScheme securityScheme = new SecurityScheme()
+                .name(jwtSchemeName)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT");
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Lemon Ticket API")
+                        .description("공연 티켓 예매 API 서버")
+                        .version("v1.0.0"))
+                .addSecurityItem(securityRequirement)
+                .components(new Components()
+                        .addSecuritySchemes(jwtSchemeName, securityScheme));
+    }
+}

--- a/src/main/java/com/flab/lemonticket/entity/User.java
+++ b/src/main/java/com/flab/lemonticket/entity/User.java
@@ -6,7 +6,7 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "User")
+@Table(name = "\"user\"")
 @Getter
 @Setter
 @Builder

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,26 @@
+spring:
+  datasource:
+    url: jdbc:mysql://mini.jh1105.xyz:5306/lemon_ticket
+    username: ${DATABASE_USERNAME}
+    password: ${DATABASE_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type: trace
+
+security:
+  jwt:
+    token:
+
+file:
+  upload-dir: ./uploads

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,26 @@
+spring:
+  datasource:
+    url: jdbc:mysql://127.0.0.1:3307/lemon_ticket?allowPublicKeyRetrieval=true&useSSL=false
+    username: lemon
+    password: lemon1234
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type: trace
+
+security:
+  jwt:
+    token:
+
+file:
+  upload-dir: ./uploads

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,26 @@
+spring:
+  datasource:
+    url: ${DATABASE_URL}
+    username: ${DATABASE_USERNAME}
+    password: ${DATABASE_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    show-sql: false
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+
+logging:
+  level:
+    org.hibernate.SQL: warn
+    root: info
+
+security:
+  jwt:
+    token:
+
+file:
+  upload-dir: ./uploads

--- a/src/test/java/com/flab/lemonticket/controller/UserControllerTest.java
+++ b/src/test/java/com/flab/lemonticket/controller/UserControllerTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@org.springframework.test.context.ActiveProfiles("test")
 class UserControllerTest {
     @LocalServerPort
     private int port;

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,29 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:lemon_ticket_test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+
+  h2:
+    console:
+      enabled: true
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+
+security:
+  jwt:
+    token:
+
+file:
+  upload-dir: ./uploads-test


### PR DESCRIPTION
## Summary
- 테스트 프로파일 H2 인메모리 DB로 분리 (`application-test.yml`)
- 프로파일별 설정 분리 (`application-dev.yml`, `application-prod.yml`)
- 글로벌 예외 처리기 (`@RestControllerAdvice`) 및 공통 API 응답 포맷 (`ApiResponse<T>`) 구현
- 에러 코드 Enum(`ErrorCode`) 및 커스텀 예외 클래스 (`BusinessException`, `NotFoundException`, `DuplicateException`, `UnauthorizedException`) 정의
- Swagger/OpenAPI 설정 및 JWT Bearer 인증 스키마 추가
- User 엔티티 H2 예약어 충돌 해결, 기존 테스트에 `@ActiveProfiles("test")` 적용

## 주요 변경 파일
| 분류 | 파일 |
|------|------|
| 환경 설정 | `application-test.yml`, `application-dev.yml`, `application-prod.yml` |
| 공통 예외 | `common/exception/ErrorCode.java`, `GlobalExceptionHandler.java`, `BusinessException.java` 등 |
| 공통 응답 | `common/response/ApiResponse.java`, `ErrorResponse.java` |
| Swagger | `config/SwaggerConfig.java`, `SecurityConfig.java` 수정 |
| 기존 수정 | `User.java` 테이블명 수정, `UserControllerTest.java` 프로파일 적용 |

## Test plan
- [x] `./gradlew compileJava compileTestJava` 정상 통과
- [ ] Swagger UI (`/swagger-ui/index.html`) 접근 확인
- [ ] 잘못된 요청 시 `ApiResponse` 에러 형식 반환 확인
- [ ] `@ActiveProfiles("test")` 적용으로 테스트 시 H2 사용 확인